### PR TITLE
Change AgentRunExtraction to have a *list* of messages

### DIFF
--- a/src/lasagna/__init__.py
+++ b/src/lasagna/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     'build_static_output_agent',
 ]
 
-__version__ = "0.11.2"
+__version__ = "0.12.0"

--- a/src/lasagna/agent_util.py
+++ b/src/lasagna/agent_util.py
@@ -119,9 +119,9 @@ def recursive_extract_messages(
         elif run['type'] == 'extraction':
             messages.extend(
                 (
-                    _recursive_extract_messages_from_tool_res([run['message']])
+                    _recursive_extract_messages_from_tool_res(run['messages'])
                     if from_layered_agents else
-                    [run['message']]
+                    run['messages']
                 ),
             )
         else:
@@ -271,7 +271,7 @@ def build_extraction_agent(
             return {
                 'agent': name,
                 'type': 'extraction',
-                'message': message,
+                'messages': [message],
                 'result': result,
             }
 
@@ -344,7 +344,7 @@ def build_agent_router(
             extraction: AgentRun = {
                 'agent': name,
                 'type': 'extraction',
-                'message': message,
+                'messages': [message],
                 'result': result,
             }
             agent = pick_agent_func(result)

--- a/src/lasagna/types.py
+++ b/src/lasagna/types.py
@@ -108,7 +108,7 @@ class AgentRunChained(AgentRunBase):
 
 class AgentRunExtraction(AgentRunBase):
     type: Literal['extraction']
-    message: Message
+    messages: List[Message]
     result: Any    # ideally, it's `ExtractionType`, and we'd inherit from Generic[ExtractionType], but that's not supported until python3.11
 
 

--- a/tests/test_agent_util.py
+++ b/tests/test_agent_util.py
@@ -180,10 +180,12 @@ async def test_model_extract():
             'end',
             {
                 'type': 'extraction',
-                'message': {
-                    'role': 'ai',
-                    'text': None,
-                },
+                'messages': [
+                    {
+                        'role': 'ai',
+                        'text': None,
+                    },
+                ],
                 'result': MyTestType(a='yes', b=6),
                 'provider': 'MockProvider',
                 'agent': 'my_extraction_agent',
@@ -196,10 +198,12 @@ async def test_model_extract():
         ),
     ]
     assert run['type'] == 'extraction'
-    assert run['message'] == {
-        'role': 'ai',
-        'text': None,
-    }
+    assert run['messages'] == [
+        {
+            'role': 'ai',
+            'text': None,
+        },
+    ]
     result = run['result']
     assert isinstance(result, MyTestType)
     assert result.a == 'yes'
@@ -285,19 +289,21 @@ def test_recursive_extract_messages():
             {
                 'agent': 'inner_agent_5',
                 'type': 'extraction',
-                'message': {
-                    'role': 'tool_call',
-                    'tools': [
-                        {
-                            'call_id': 'call002',
-                            'call_type': 'function',
-                            'function': {
-                                'name': 'foo',
-                                'arguments': '{"value": 7}',
+                'messages': [
+                    {
+                        'role': 'tool_call',
+                        'tools': [
+                            {
+                                'call_id': 'call002',
+                                'call_type': 'function',
+                                'function': {
+                                    'name': 'foo',
+                                    'arguments': '{"value": 7}',
+                                },
                             },
-                        },
-                    ],
-                },
+                        ],
+                    },
+                ],
                 'result': {'value': 7},
             },
             {


### PR DESCRIPTION
Due to _overwhelming_ pressure from the Lasagna community, we've decided to change `AgentRunExtraction` to have a *list* of messages (rather than a single message).